### PR TITLE
[Feature] Add winning modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,13 @@
     <button id="solve">Show Solution</button>
   </div>
 
+  <div id="win-modal">
+    <div id="modal-content">
+      <p>Congratulations you won!</p>
+      <button id="restart-btn">Restart</button>
+    </div>
+  </div>
+
   <!-- Link to the JavaScript file -->
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,8 @@ let mazeContainer = document.getElementById("maze-container");
 let sizeInput = document.getElementById("size");
 let generateButton = document.getElementById("generate");
 let solveButton = document.getElementById("solve");
+let winningModal = document.getElementById("win-modal");
+let restartBtn = document.getElementById("restart-btn");
 
 let size = parseInt(sizeInput.value);
 let maze = generateMaze(size);
@@ -27,6 +29,16 @@ solveButton.addEventListener("click", () => {
   PlayerCanMove = false;
   const solution = solveMaze(maze, size);
   animateSolution(solution);
+});
+
+restartBtn.addEventListener("click", () => {
+  // Reset player position and allow movement again
+  playerPosition = { x: 0, y: 0 };
+  visited = {};
+  PlayerCanMove = true;
+
+  winningModal.style.display = "none";
+  renderMaze(maze)
 });
 
 document.addEventListener("keydown", movePlayer);
@@ -135,7 +147,7 @@ function solveMaze(maze, size) {
     { x: 1, y: 0 },
     { x: -1, y: 0 },
     { x: 0, y: 1 },
-    { x: 0, y: -1 }
+    { x: 0, y: -1 },
   ];
   const start = { x: 0, y: 0 };
   const end = { x: size - 1, y: size - 1 };
@@ -200,7 +212,7 @@ function movePlayer(event) {
     ArrowUp: { dx: 0, dy: -1 },
     ArrowDown: { dx: 0, dy: 1 },
     ArrowLeft: { dx: -1, dy: 0 },
-    ArrowRight: { dx: 1, dy: 0 }
+    ArrowRight: { dx: 1, dy: 0 },
   };
 
   if (PlayerCanMove) {
@@ -222,6 +234,12 @@ function movePlayer(event) {
         updatePlayerPosition(dx, dy);
       }
     }
+  }
+
+  // Checking if player reaches endpoint/target, show up win modal
+  if (playerPosition.x === size - 1 && playerPosition.y === size - 1) {
+    PlayerCanMove = false;
+    winningModal.style.display = "block";
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ body {
   margin-top: 125px;
   background: linear-gradient(135deg, #1e293b, #0f172a);
   color: #f1f5f9;
-  font-family: 'Arial', sans-serif;
+  font-family: "Arial", sans-serif;
   overflow: hidden;
 }
 
@@ -136,4 +136,31 @@ span.to-bottom::after {
   top: 50%;
   left: 100px;
   transform: translate(-50%, -50%);
+}
+
+#win-modal {
+  display: none;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  z-index: 10;
+  background-color: rgba(14, 14, 14, 0.5);
+}
+
+#modal-content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 10rem;
+  width: 16rem;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  translate: -50% -50%;
+  padding: 1rem 1.5rem;
+  border: 3px solid #1c2739;
+  border-radius: 10px;
+  background-color: #0ea5e9;
 }


### PR DESCRIPTION
Fixes issue #1 

This PR adds:
- Winning modal at the html (initially hidden)
- When user reaches the ending point, shows winning modal
- Restart functionality

## Summary by Sourcery

Add a winning modal that appears when the user reaches the end of the maze. Implement restart functionality in the modal, allowing the user to reset the maze and play again.

New Features:
- Display a "Congratulations" modal when the user successfully completes the maze.

Tests:
- Ensure the winning modal appears when the player reaches the maze's end.